### PR TITLE
Feat: 요리 레시피 삭제 구현

### DIFF
--- a/db_queries/table_definition.sql
+++ b/db_queries/table_definition.sql
@@ -150,7 +150,7 @@ CREATE TABLE recommended_menu (
     user_id BIGINT NOT NULL,
     recipe_id BIGINT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES USER(user_id),
-    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id)
+    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id) ON DELETE CASCADE
 ) ENGINE=INNODB AUTO_INCREMENT=1 COMMENT='추천요리' DEFAULT CHARSET=UTF8;
 
 CREATE TABLE recipe_board_like (
@@ -175,7 +175,7 @@ CREATE TABLE ai_recipe (
     ai_menu_name VARCHAR(255) NOT NULL,
     ai_menu_ingredient TEXT NOT NULL,
     recipe_id BIGINT NOT NULL,
-    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id)
+    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id) ON DELETE CASCADE 
 ) ENGINE=INNODB AUTO_INCREMENT=1 COMMENT='AI요리레시피' DEFAULT CHARSET=UTF8;
 
 CREATE TABLE public_data_recipe (
@@ -184,7 +184,7 @@ CREATE TABLE public_data_recipe (
     public_data_menu_ingredient TEXT NOT NULL,
     public_data_menu_image TEXT,
     recipe_id BIGINT NOT NULL,
-    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id)
+    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id) ON DELETE CASCADE
 ) ENGINE=INNODB AUTO_INCREMENT=1 COMMENT='공공데이터요리레시피' DEFAULT CHARSET=UTF8;
 
 CREATE TABLE recipe_manual (
@@ -193,7 +193,7 @@ CREATE TABLE recipe_manual (
     manual_menu_image TEXT,
     manual_content TEXT NOT NULL,
     recipe_id BIGINT NOT NULL,
-    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id)
+    FOREIGN KEY (recipe_id) REFERENCES recipe(recipe_id) ON DELETE CASCADE
 ) ENGINE=INNODB AUTO_INCREMENT=1 COMMENT='요리메뉴얼' DEFAULT CHARSET=UTF8;
 
 CREATE TABLE recipe_board_manual (

--- a/server/src/main/java/com/avengers/yoribogo/recipe/controller/RecipeController.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipe/controller/RecipeController.java
@@ -41,9 +41,10 @@ public class RecipeController {
     }
 
     // 요리 레시피 수정
-    @PutMapping
-    public ResponseDTO<RecipeDTO> updateRecipe(@RequestBody RecipeDTO modifyRecipeDTO) {
-        RecipeDTO recipeDTO = recipeService.modifyRecipe(modifyRecipeDTO);
+    @PutMapping("/{recipeId}")
+    public ResponseDTO<RecipeDTO> updateRecipe(@PathVariable("recipeId") Long recipeId,
+                                               @RequestBody RecipeDTO modifyRecipeDTO) {
+        RecipeDTO recipeDTO = recipeService.modifyRecipe(recipeId, modifyRecipeDTO);
         return ResponseDTO.ok(recipeDTO);
     }
 

--- a/server/src/main/java/com/avengers/yoribogo/recipe/controller/RecipeController.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipe/controller/RecipeController.java
@@ -47,4 +47,11 @@ public class RecipeController {
         return ResponseDTO.ok(recipeDTO);
     }
 
+    // 요리 레시피 삭제
+    @DeleteMapping("/{recipeId}")
+    public ResponseDTO<RecipeDTO> deleteRecipe(@PathVariable("recipeId") Long recipeId) {
+        recipeService.removeRecipe(recipeId);
+        return ResponseDTO.ok(null);
+    }
+
 }

--- a/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeService.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeService.java
@@ -15,7 +15,7 @@ public interface RecipeService {
     Page<RecipeDTO> findRecipeByMenuName(String menuName, Integer pageNo);
 
     // 요리 레시피 수정
-    RecipeDTO modifyRecipe(RecipeDTO modifyRecipeDTO);
+    RecipeDTO modifyRecipe(Long recipeId, RecipeDTO modifyRecipeDTO);
 
     // 요리 레시피 삭제
     void removeRecipe(Long recipeId);

--- a/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeService.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeService.java
@@ -14,6 +14,10 @@ public interface RecipeService {
     // 요리 레시피 요리 이름으로 조회
     Page<RecipeDTO> findRecipeByMenuName(String menuName, Integer pageNo);
 
+    // 요리 레시피 수정
     RecipeDTO modifyRecipe(RecipeDTO modifyRecipeDTO);
+
+    // 요리 레시피 삭제
+    void removeRecipe(Long recipeId);
 
 }

--- a/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeServiceImpl.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeServiceImpl.java
@@ -97,10 +97,9 @@ public class RecipeServiceImpl implements RecipeService {
         return new PageImpl<>(recipeDTOList, pageable, recipePage.getTotalElements());
     }
 
+    // 요리 레시피 수정
     @Override
     public RecipeDTO modifyRecipe(RecipeDTO modifyRecipeDTO) {
-        // 관리자 여부 확인하는 로직 추가 예정
-
         // 기존 엔티티 조회
         Recipe existingRecipe = recipeRepository.findById(modifyRecipeDTO.getRecipeId())
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RECIPE));
@@ -112,6 +111,16 @@ public class RecipeServiceImpl implements RecipeService {
         existingRecipe.setUserId(modifyRecipeDTO.getUserId());
 
         return modelMapper.map(recipeRepository.save(existingRecipe), RecipeDTO.class);
+    }
+
+    // 요리 레시피 삭제
+    @Override
+    public void removeRecipe(Long recipeId) {
+        // 기존 엔티티 조회
+        Recipe existingRecipe = recipeRepository.findById(recipeId)
+                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RECIPE));
+
+        recipeRepository.delete(existingRecipe);
     }
 
     // 페이지 내 엔티티를 DTO로 변환해주는 메소드

--- a/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeServiceImpl.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipe/service/RecipeServiceImpl.java
@@ -99,9 +99,9 @@ public class RecipeServiceImpl implements RecipeService {
 
     // 요리 레시피 수정
     @Override
-    public RecipeDTO modifyRecipe(RecipeDTO modifyRecipeDTO) {
+    public RecipeDTO modifyRecipe(Long recipeId, RecipeDTO modifyRecipeDTO) {
         // 기존 엔티티 조회
-        Recipe existingRecipe = recipeRepository.findById(modifyRecipeDTO.getRecipeId())
+        Recipe existingRecipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RECIPE));
 
         // 엔티티 정보 수정

--- a/server/src/test/java/com/avengers/yoribogo/recipe/service/RecipeServiceTests.java
+++ b/server/src/test/java/com/avengers/yoribogo/recipe/service/RecipeServiceTests.java
@@ -1,5 +1,6 @@
 package com.avengers.yoribogo.recipe.service;
 
+import com.avengers.yoribogo.common.exception.CommonException;
 import com.avengers.yoribogo.recipe.dto.RecipeDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -95,6 +96,24 @@ class RecipeServiceTests {
 
         // 요소를 로그로 찍기
         log.info(recipeDTO.toString());
+    }
+
+    @DisplayName("요리 레시피 삭제 테스트")
+    @Test
+    void testRemoveRecipe() {
+        // Given
+        Long recipeId = 1L;
+
+        // When
+        recipeService.removeRecipe(recipeId);
+
+        // Then
+        Assertions.assertThrows(CommonException.class,
+            () -> {
+                recipeService.removeRecipe(recipeId);
+            }
+            , "요리 레시피가 삭제되지 않았습니다."
+        );
     }
 
 }

--- a/server/src/test/java/com/avengers/yoribogo/recipe/service/RecipeServiceTests.java
+++ b/server/src/test/java/com/avengers/yoribogo/recipe/service/RecipeServiceTests.java
@@ -109,9 +109,7 @@ class RecipeServiceTests {
 
         // Then
         Assertions.assertThrows(CommonException.class,
-            () -> {
-                recipeService.removeRecipe(recipeId);
-            }
+            () -> recipeService.removeRecipe(recipeId)
             , "요리 레시피가 삭제되지 않았습니다."
         );
     }

--- a/server/src/test/java/com/avengers/yoribogo/recipe/service/RecipeServiceTests.java
+++ b/server/src/test/java/com/avengers/yoribogo/recipe/service/RecipeServiceTests.java
@@ -79,9 +79,9 @@ class RecipeServiceTests {
     @Test
     void testModifyRecipe() {
         // Given
+        Long recipeId = 1L;
         RecipeDTO recipeDTO = RecipeDTO
                 .builder()
-                .recipeId(1L)
                 .menuName("김치찌개")
                 .menuIngredient("김치")
                 .menuImage("http://www.foodsafetykorea.go.kr/uploadimg/cook/10_00028_2.png")
@@ -89,7 +89,7 @@ class RecipeServiceTests {
                 .build();
 
         // When
-        recipeDTO = recipeService.modifyRecipe(recipeDTO);
+        recipeDTO = recipeService.modifyRecipe(recipeId, recipeDTO);
 
         // Then
         Assertions.assertNotNull(recipeDTO, "레시피가 null 입니다.");


### PR DESCRIPTION
---
name: 기능 개발 이슈
about: 요리 레시피 삭제 구현
title: Feat: 요리 레시피 삭제 구현
labels: enhancement
assignees: @woodart8 

---

## 무슨 이유로 코드를 개발했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
```Java
    // 요리 레시피 삭제
    @Override
    public void removeRecipe(Long recipeId) {
        // 기존 엔티티 조회
        Recipe existingRecipe = recipeRepository.findById(recipeId)
                .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RECIPE));

        recipeRepository.delete(existingRecipe);
    }
```

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/44bd185d-9a62-4848-a043-05cf52f84e4c)


## 테스트 계획 또는 완료 사항(테스트인 경우)
- [x] 삭제 처리가 잘 되었는가?

## 테스트코드
```Java
    @DisplayName("요리 레시피 삭제 테스트")
    @Test
    void testRemoveRecipe() {
        // Given
        Long recipeId = 1L;

        // When
        recipeService.removeRecipe(recipeId);

        // Then
        Assertions.assertThrows(CommonException.class,
            () -> recipeService.removeRecipe(recipeId)
            , "요리 레시피가 삭제되지 않았습니다."
        );
    }
```

## 기타 참고 사항
- 

## 닫은 이슈(기능)
close #5
