### PR TITLE
Feat: 아이디,닉네임 중복 검증 api 추가

### DIFF
--- a/server/src/main/java/com/avengers/yoribogo/user/controller/UserController.java
+++ b/server/src/main/java/com/avengers/yoribogo/user/controller/UserController.java
@@ -18,6 +18,9 @@ import com.avengers.yoribogo.user.domain.vo.signup.RequestResistEnterpriseUserVO
 import com.avengers.yoribogo.user.dto.UserDTO;
 import com.avengers.yoribogo.user.dto.email.EmailVerificationUserIdRequestDTO;
 import com.avengers.yoribogo.user.dto.email.EmailVerificationUserPasswordRequestDTO;
+import com.avengers.yoribogo.user.dto.validate.BooleanResponseDTO;
+import com.avengers.yoribogo.user.dto.validate.RequestNicknameDTO;
+import com.avengers.yoribogo.user.dto.validate.RequestUserAuthIdentifierDTO;
 import com.avengers.yoribogo.user.service.EmailVerificationService;
 import com.avengers.yoribogo.user.service.OAuth2LoginService;
 import com.avengers.yoribogo.user.service.UserService;
@@ -197,5 +200,20 @@ public class UserController {
         // ResponseUserVO로 변환하는 대신 UserDTO를 직접 응답으로 사용
         return ResponseDTO.ok(savedUserDTO);
     }
+
+    /* 설명. 7. 닉네임 중복 검증  */
+    @PostMapping("/nickname/validate")
+    public ResponseDTO<BooleanResponseDTO> validateNickname(@RequestBody RequestNicknameDTO requestNicknameDTO) {
+        BooleanResponseDTO booleanResponseDTO= userService. getUserByNicknameForDuplicate(requestNicknameDTO.getNickname());
+        return ResponseDTO.ok(booleanResponseDTO);
+    }
+
+    /* 설명. 8. 아이디 중복 검증  */
+    @PostMapping("/user-id/validate")
+    public ResponseDTO<BooleanResponseDTO> getUserByUserIdentifier(@RequestBody RequestUserAuthIdentifierDTO requestUserIdentifierDTO) {
+        BooleanResponseDTO booleanResponseDTO = userService.getUserByUserAuthId(requestUserIdentifierDTO.getUserAuthId());
+        return ResponseDTO.ok(booleanResponseDTO);
+    }
+
 
 }

--- a/server/src/main/java/com/avengers/yoribogo/user/dto/validate/BooleanResponseDTO.java
+++ b/server/src/main/java/com/avengers/yoribogo/user/dto/validate/BooleanResponseDTO.java
@@ -1,0 +1,14 @@
+package com.avengers.yoribogo.user.dto.validate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BooleanResponseDTO {
+    @JsonProperty("exist") // Lombok이 생성한 getter 이름을 맞추도록 필드명 수정
+    private boolean isExist;
+}

--- a/server/src/main/java/com/avengers/yoribogo/user/dto/validate/RequestNicknameDTO.java
+++ b/server/src/main/java/com/avengers/yoribogo/user/dto/validate/RequestNicknameDTO.java
@@ -1,0 +1,10 @@
+package com.avengers.yoribogo.user.dto.validate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class RequestNicknameDTO {
+    @JsonProperty("nickname")
+    private String nickname; // 변경, 가입 경로 + 사용자id 조합
+}

--- a/server/src/main/java/com/avengers/yoribogo/user/dto/validate/RequestUserAuthIdDTO.java
+++ b/server/src/main/java/com/avengers/yoribogo/user/dto/validate/RequestUserAuthIdDTO.java
@@ -1,0 +1,18 @@
+package com.avengers.yoribogo.user.dto.validate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RequestUserAuthIdDTO {
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @JsonProperty("nickname")
+    private String nickname;
+
+    @NotBlank(message = "이메일은 필수 항목입니다.")
+    @Email(message = "올바른 이메일 형식을 입력해 주세요.")
+    @JsonProperty("email")
+    private String email;
+}

--- a/server/src/main/java/com/avengers/yoribogo/user/dto/validate/RequestUserAuthIdentifierDTO.java
+++ b/server/src/main/java/com/avengers/yoribogo/user/dto/validate/RequestUserAuthIdentifierDTO.java
@@ -1,0 +1,10 @@
+package com.avengers.yoribogo.user.dto.validate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class RequestUserAuthIdentifierDTO {
+    @JsonProperty("user_auth_id")
+    private String userAuthId; // 변경, 가입 경로 + 사용자id 조합
+}

--- a/server/src/main/java/com/avengers/yoribogo/user/repository/UserRepository.java
+++ b/server/src/main/java/com/avengers/yoribogo/user/repository/UserRepository.java
@@ -13,16 +13,16 @@ public interface UserRepository extends JpaRepository<UserEntity,Long> {
     @Query("SELECT COALESCE(MAX(u.userId), 0) FROM UserEntity u")
     Long findMaxUserId();
 
-    UserEntity findByUserIdentifier(String userIdentifier);
+    Optional<UserEntity> findByUserIdentifier(String userIdentifier);
 
     Optional<UserEntity> findByNickname(String nickname);
 
     // 이름, 가입 경로, 이메일로 사용자 찾기
-    UserEntity findByNicknameAndSignupPathAndEmail(String userName, SignupPath signupPath, String email);
+    Optional<UserEntity> findByNicknameAndSignupPathAndEmail(String userName, SignupPath signupPath, String email);
 
     // 아이디와 이메일로 사용자 찾기
-    UserEntity findByUserAuthIdAndEmail(String userAuthId, String email);
+    Optional<UserEntity> findByUserAuthIdAndEmail(String userAuthId, String email);
 
     // userAuthId로 사용자 조회
-    UserEntity findByUserAuthId(String userAuthId);
+    Optional<UserEntity> findByUserAuthId(String userAuthId);
 }


### PR DESCRIPTION
---
name: 아이디,닉네임 중복 검증 api 추가
about: 아이디, 닉네임 중복 검증시 reponse data의 "exist" 필드가 True
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 개발했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트


## 소스코드1
```Java
// 설명. 닉네임 중복 여부 확인
    public BooleanResponseDTO getUserByNicknameForDuplicate(String nickname) {
        // 닉네임이 존재하는지 여부를 BooleanResponseDTO로 바로 매핑
        return new BooleanResponseDTO(userRepository.findByNickname(nickname).isPresent());
    }

    // 설명. 사용자 인증 아이디 중복 여부 확인
    public BooleanResponseDTO getUserByUserAuthId(String userAuthId) {
        // 사용자 인증 아이디가 존재하는지 여부를 BooleanResponseDTO로 바로 매핑
        return new BooleanResponseDTO(userRepository.findByUserAuthId(userAuthId).isPresent());
    }

```


## 닫은 이슈(기능)
close #26
clsoe #27 
