### PR TITLE
Feat: 즐겨찾기 상태값 반환 로직 추가

### DIFF
--- a/server/src/main/java/com/avengers/yoribogo/recipeboard/controller/RecipeBoardFavoriteController.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipeboard/controller/RecipeBoardFavoriteController.java
@@ -1,15 +1,11 @@
 package com.avengers.yoribogo.recipeboard.controller;
 
 import com.avengers.yoribogo.common.ResponseDTO;
-import com.avengers.yoribogo.recipeboard.dto.MyFavoriteBoardDTO;
-import com.avengers.yoribogo.recipeboard.dto.RecipeBoardDTO;
-import com.avengers.yoribogo.recipeboard.dto.RecipeBoardFavoriteDTO;
-import com.avengers.yoribogo.recipeboard.dto.ResponseFavoriteDTO;
+import com.avengers.yoribogo.recipeboard.dto.*;
 import com.avengers.yoribogo.recipeboard.service.RecipeBoardFavoriteService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -42,5 +38,13 @@ public class RecipeBoardFavoriteController {
         recipeBoardFavoriteService.removeFavorite(userId, recipeBoardId);
         return ResponseDTO.ok(null);
     }
+
+    @GetMapping("/users/{userId}/boards/{recipeBoardId}/status")
+    public ResponseDTO<?> getFavoriteStatus(@PathVariable("userId") Long userId,
+                                            @PathVariable("recipeBoardId") Long recipeBoardId) {
+        FavoriteStatusDTO favoriteStatusDTO = recipeBoardFavoriteService.getFavoriteStatus(userId, recipeBoardId);
+        return ResponseDTO.ok(favoriteStatusDTO);
+    }
+
 
 }

--- a/server/src/main/java/com/avengers/yoribogo/recipeboard/dto/FavoriteStatusDTO.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipeboard/dto/FavoriteStatusDTO.java
@@ -1,0 +1,16 @@
+package com.avengers.yoribogo.recipeboard.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class FavoriteStatusDTO {
+
+    @JsonProperty("exists")
+    private boolean isExists;
+
+}

--- a/server/src/main/java/com/avengers/yoribogo/recipeboard/service/RecipeBoardFavoriteService.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipeboard/service/RecipeBoardFavoriteService.java
@@ -1,9 +1,6 @@
 package com.avengers.yoribogo.recipeboard.service;
 
-import com.avengers.yoribogo.recipeboard.dto.MyFavoriteBoardDTO;
-import com.avengers.yoribogo.recipeboard.dto.RecipeBoardDTO;
-import com.avengers.yoribogo.recipeboard.dto.RecipeBoardFavoriteDTO;
-import com.avengers.yoribogo.recipeboard.dto.ResponseFavoriteDTO;
+import com.avengers.yoribogo.recipeboard.dto.*;
 import org.springframework.data.domain.Page;
 
 public interface RecipeBoardFavoriteService {
@@ -13,4 +10,6 @@ public interface RecipeBoardFavoriteService {
     Page<MyFavoriteBoardDTO> findFavoriteBoardsByUserId(Long userId, Integer pageNo);
 
     void removeFavorite(Long userId, Long recipeBoardId);
+
+    FavoriteStatusDTO getFavoriteStatus(Long userId, Long recipeBoardId);
 }

--- a/server/src/main/java/com/avengers/yoribogo/recipeboard/service/RecipeBoardFavoriteServiceImpl.java
+++ b/server/src/main/java/com/avengers/yoribogo/recipeboard/service/RecipeBoardFavoriteServiceImpl.java
@@ -4,10 +4,7 @@ import com.avengers.yoribogo.common.exception.CommonException;
 import com.avengers.yoribogo.common.exception.ErrorCode;
 import com.avengers.yoribogo.recipeboard.domain.RecipeBoard;
 import com.avengers.yoribogo.recipeboard.domain.RecipeBoardFavorite;
-import com.avengers.yoribogo.recipeboard.dto.MyFavoriteBoardDTO;
-import com.avengers.yoribogo.recipeboard.dto.RecipeBoardDTO;
-import com.avengers.yoribogo.recipeboard.dto.RecipeBoardFavoriteDTO;
-import com.avengers.yoribogo.recipeboard.dto.ResponseFavoriteDTO;
+import com.avengers.yoribogo.recipeboard.dto.*;
 import com.avengers.yoribogo.recipeboard.repository.RecipeBoardFavoriteRepository;
 import com.avengers.yoribogo.recipeboard.repository.RecipeBoardRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -98,6 +95,13 @@ public class RecipeBoardFavoriteServiceImpl implements RecipeBoardFavoriteServic
                 .orElseThrow(() -> new CommonException(ErrorCode.NOT_FOUND_RECIPE_BOARD));
 
         recipeBoardFavoriteRepository.delete(favorite);
+    }
+
+    @Override
+    public FavoriteStatusDTO getFavoriteStatus(Long userId, Long recipeBoardId) {
+
+        boolean isExists = recipeBoardFavoriteRepository.existsByUserIdAndRecipeBoard_RecipeBoardId(userId, recipeBoardId);
+        return new FavoriteStatusDTO(isExists);
     }
 
     //    @Override


### PR DESCRIPTION
---
name: 기능 개발 이슈
about: 게시글의 즐겨찾기 상태값만 반환하는 로직 추가했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 개발했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스
- [ ] 테스트

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 프론트에서 게시글 상세 조회 시 즐겨찾기 상태값이 false일 때와 true일 때 다른 컴포넌트를 띄워주기 위해 개발했습니다.

## 관련 스크린 샷 

## 테스트 계획 또는 완료 사항(테스트인 경우)
- [ ] 테스트항목 1
- [ ] 테스트항목 2

## 소스코드1
```Java


```

## 소스코드1
```Javascript


```

## 기타 참고 사항
- 

## 닫은 이슈(기능)
close #
